### PR TITLE
[User] 도메인 기반 User 패키지 및 엔티티 작성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,11 +25,17 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
     compileOnly("org.projectlombok:lombok")
+
     developmentOnly("org.springframework.boot:spring-boot-devtools")
+
     runtimeOnly("org.mariadb.jdbc:mariadb-java-client")
+
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     annotationProcessor("org.projectlombok:lombok")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/java/domainstructure/domainstructure/core/common/Email.java
+++ b/src/main/java/domainstructure/domainstructure/core/common/Email.java
@@ -21,7 +21,7 @@ public class Email {
     }
 
     @JsonCreator
-    public static Email of(String value) {
+    public static Email of(final String value) {
         return new Email(value);
     }
 

--- a/src/main/java/domainstructure/domainstructure/core/common/Email.java
+++ b/src/main/java/domainstructure/domainstructure/core/common/Email.java
@@ -1,5 +1,7 @@
 package domainstructure.domainstructure.core.common;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -18,6 +20,7 @@ public class Email {
         this.value = value;
     }
 
+    @JsonCreator
     public static Email of(String value) {
         return new Email(value);
     }
@@ -35,6 +38,7 @@ public class Email {
     }
 
     @Override
+    @JsonValue
     public String toString() {
         return value;
     }

--- a/src/main/java/domainstructure/domainstructure/core/common/Email.java
+++ b/src/main/java/domainstructure/domainstructure/core/common/Email.java
@@ -1,0 +1,41 @@
+package domainstructure.domainstructure.core.common;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Getter
+@EqualsAndHashCode
+public class Email {
+    private static final String EMAIL_REGEX = "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$";
+    private static final String INVALID_EMAIL_MESSAGE = "Invalid email address";
+    private static final int MAX_EMAIL_LENGTH = 254;
+    private final String value;
+
+    private Email(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    public static Email of(String value) {
+        return new Email(value);
+    }
+
+    private void validate(String value) {
+        Optional.ofNullable(value)
+                .filter(v -> !v.isBlank())
+                .filter(this::isValidFormat)
+                .filter(v -> v.length() <= MAX_EMAIL_LENGTH)
+                .orElseThrow(() -> new IllegalArgumentException(INVALID_EMAIL_MESSAGE));
+    }
+
+    private boolean isValidFormat(String value) {
+        return value.matches(EMAIL_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/core/common/vo/Email.java
+++ b/src/main/java/domainstructure/domainstructure/core/common/vo/Email.java
@@ -1,4 +1,4 @@
-package domainstructure.domainstructure.core.common;
+package domainstructure.domainstructure.core.common.vo;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/src/main/java/domainstructure/domainstructure/core/user/model/Address.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/model/Address.java
@@ -8,9 +8,9 @@ import lombok.Getter;
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Address {
+    private final City city;
     @EqualsAndHashCode.Include
     private final Long id;
-    private final City city;
     private final String street; // TODO: VO로 변경해야함 @Lyght.Kim
     private final String zipcode; // TODO: VO로 변경해야함 @Lyght.Kim
 

--- a/src/main/java/domainstructure/domainstructure/core/user/model/Address.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/model/Address.java
@@ -1,17 +1,23 @@
-package domainstructure.domainstructure.core.user.vo;
+package domainstructure.domainstructure.core.user.model;
 
+import domainstructure.domainstructure.core.user.vo.City;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
-@Builder(toBuilder = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Address {
+    @EqualsAndHashCode.Include
+    private final Long id;
     private final City city;
     private final String street; // TODO: VO로 변경해야함 @Lyght.Kim
     private final String zipcode; // TODO: VO로 변경해야함 @Lyght.Kim
 
-    private Address(City city, String street, String zipcode) {
+    @Builder(toBuilder = true)
+    private Address(Long id, City city, String street, String zipcode) {
         validate(city, street, zipcode);
+        this.id = id;
         this.city = city;
         this.street = street;
         this.zipcode = zipcode;
@@ -19,6 +25,15 @@ public class Address {
 
     public static Address of(final City city, final String street, final String zipcode) {
         return Address.builder()
+                      .city(city)
+                      .street(street)
+                      .zipcode(zipcode)
+                      .build();
+    }
+
+    public static Address of(final long id, final City city, final String street, final String zipcode) {
+        return Address.builder()
+                      .id(id)
                       .city(city)
                       .street(street)
                       .zipcode(zipcode)

--- a/src/main/java/domainstructure/domainstructure/core/user/model/Profile.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/model/Profile.java
@@ -10,13 +10,13 @@ import java.time.LocalDate;
 public class Profile {
     private final LocalDate birthday;
     private final Long id;
-    private final Nickname name;
+    private final Nickname nickname;
 
     @Builder(toBuilder = true)
-    private Profile(Long id, Nickname name, LocalDate birthday) {
-        validate(name, birthday);
+    private Profile(Long id, Nickname nickname, LocalDate birthday) {
+        validate(nickname, birthday);
         this.id = id;
-        this.name = name;
+        this.nickname = nickname;
         this.birthday = birthday;
     }
 

--- a/src/main/java/domainstructure/domainstructure/core/user/model/Profile.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/model/Profile.java
@@ -1,0 +1,41 @@
+package domainstructure.domainstructure.core.user.model;
+
+import domainstructure.domainstructure.core.user.vo.Nickname;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class Profile {
+    private final LocalDate birthday;
+    private final Long id;
+    private final Nickname name;
+
+    @Builder(toBuilder = true)
+    private Profile(Long id, Nickname name, LocalDate birthday) {
+        validate(name, birthday);
+        this.id = id;
+        this.name = name;
+        this.birthday = birthday;
+    }
+
+    public static Profile of(Long id, Nickname name, LocalDate birthday) {
+        return new Profile(id, name, birthday);
+    }
+
+    public static Profile of(Nickname name, LocalDate birthday) {
+        return new Profile(null, name, birthday);
+    }
+
+    private void validate(Nickname name, LocalDate birthday) {
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null");
+        }
+        if (birthday == null) {
+            throw new IllegalArgumentException("birthday must not be null");
+        }
+    }
+
+
+}

--- a/src/main/java/domainstructure/domainstructure/core/user/model/User.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/model/User.java
@@ -1,0 +1,34 @@
+package domainstructure.domainstructure.core.user.model;
+
+import domainstructure.domainstructure.core.user.support.UserIDGenerator;
+import domainstructure.domainstructure.core.user.vo.Account;
+import domainstructure.domainstructure.core.user.vo.UserID;
+import lombok.Builder;
+
+public class User {
+    private final Account account;
+    private final Address address;
+    private final UserID id;
+    private final Profile profile;
+
+    @Builder(toBuilder = true)
+    private User(UserID id, Account account, Profile profile, Address address) {
+        this.id = id;
+        this.account = account;
+        this.profile = profile;
+        this.address = address;
+    }
+
+    public static User of(UserID id, Account account, Profile profile, Address address) {
+        return User.builder().id(id).account(account).profile(profile).address(address).build();
+    }
+
+    public static User create(Account account, Profile profile, Address address) {
+        return User.builder()
+                   .id(UserIDGenerator.generate())
+                   .account(account)
+                   .profile(profile)
+                   .address(address)
+                   .build();
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/core/user/model/User.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/model/User.java
@@ -4,7 +4,13 @@ import domainstructure.domainstructure.core.user.support.UserIDGenerator;
 import domainstructure.domainstructure.core.user.vo.Account;
 import domainstructure.domainstructure.core.user.vo.UserID;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
+@Getter
+@EqualsAndHashCode
+@ToString
 public class User {
     private final Account account;
     private final Address address;

--- a/src/main/java/domainstructure/domainstructure/core/user/support/UserIDGenerator.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/support/UserIDGenerator.java
@@ -1,0 +1,15 @@
+package domainstructure.domainstructure.core.user.support;
+
+import domainstructure.domainstructure.core.user.vo.UserID;
+
+import java.util.UUID;
+
+public class UserIDGenerator {
+    private UserIDGenerator() {
+    }
+
+    public static UserID generate() {
+        return UserID.of(UUID.randomUUID().toString());
+    }
+
+}

--- a/src/main/java/domainstructure/domainstructure/core/user/support/UserIDGenerator.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/support/UserIDGenerator.java
@@ -1,13 +1,12 @@
 package domainstructure.domainstructure.core.user.support;
 
 import domainstructure.domainstructure.core.user.vo.UserID;
+import lombok.experimental.UtilityClass;
 
 import java.util.UUID;
 
+@UtilityClass
 public class UserIDGenerator {
-    private UserIDGenerator() {
-    }
-
     public static UserID generate() {
         return UserID.of(UUID.randomUUID().toString());
     }

--- a/src/main/java/domainstructure/domainstructure/core/user/type/CityType.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/type/CityType.java
@@ -1,0 +1,35 @@
+package domainstructure.domainstructure.core.user.type;
+
+import lombok.Getter;
+
+@Getter
+public enum CityType {
+    SEOUL("서울특별시"),
+    BUSAN("부산광역시"),
+    DAEGU("대구광역시"),
+    INCHEON("인천광역시"),
+    GWANGJU("광주광역시"),
+    DAEJEON("대전광역시"),
+    ULSAN("울산광역시"),
+    SEJONG("세종특별자치시");
+
+    private final String displayName;
+
+    CityType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public static CityType from(String value) {
+        for (CityType city : values()) {
+            if (city.displayName.equals(value)) {
+                return city;
+            }
+        }
+        throw new IllegalArgumentException("Unknown city name: " + value);
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/core/user/vo/Account.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/vo/Account.java
@@ -1,6 +1,6 @@
 package domainstructure.domainstructure.core.user.vo;
 
-import domainstructure.domainstructure.core.common.Email;
+import domainstructure.domainstructure.core.common.vo.Email;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;

--- a/src/main/java/domainstructure/domainstructure/core/user/vo/Account.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/vo/Account.java
@@ -1,0 +1,37 @@
+package domainstructure.domainstructure.core.user.vo;
+
+import domainstructure.domainstructure.core.common.Email;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@Builder(toBuilder = true)
+public class Account {
+    private final HashedPassword password;
+    private final Email username;
+
+    private Account(Email username, HashedPassword password) {
+        validate(username, password);
+        this.username = username;
+        this.password = password;
+    }
+
+    public static Account of(final Email username, final HashedPassword password) {
+        return Account.builder()
+                      .username(username)
+                      .password(password)
+                      .build();
+    }
+
+    private void validate(Email username, HashedPassword password) {
+        if (username == null) {
+            throw new IllegalArgumentException("username must not be null");
+        }
+
+        if (password == null) {
+            throw new IllegalArgumentException("password must not be null");
+        }
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/core/user/vo/Address.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/vo/Address.java
@@ -6,24 +6,28 @@ import lombok.Getter;
 @Getter
 @Builder(toBuilder = true)
 public class Address {
-    private final String city;
-    private final String street;
-    private final String zipcode;
+    private final City city;
+    private final String street; // TODO: VO로 변경해야함 @Lyght.Kim
+    private final String zipcode; // TODO: VO로 변경해야함 @Lyght.Kim
 
-    private Address(String city, String street, String zipcode) {
+    private Address(City city, String street, String zipcode) {
         validate(city, street, zipcode);
         this.city = city;
         this.street = street;
         this.zipcode = zipcode;
     }
 
-    public static Address of(final String city, final String street, final String zipcode) {
-        return Address.builder().city(city).street(street).zipcode(zipcode).build();
+    public static Address of(final City city, final String street, final String zipcode) {
+        return Address.builder()
+                      .city(city)
+                      .street(street)
+                      .zipcode(zipcode)
+                      .build();
     }
 
-    private void validate(String city, String street, String zipcode) {
-        if (city == null || city.isBlank()) {
-            throw new IllegalArgumentException("city must not be null or blank");
+    private void validate(City city, String street, String zipcode) {
+        if (city == null) {
+            throw new IllegalArgumentException("city must not be null");
         }
         if (street == null || street.isBlank()) {
             throw new IllegalArgumentException("street must not be null or blank");

--- a/src/main/java/domainstructure/domainstructure/core/user/vo/Address.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/vo/Address.java
@@ -1,0 +1,35 @@
+package domainstructure.domainstructure.core.user.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(toBuilder = true)
+public class Address {
+    private final String city;
+    private final String street;
+    private final String zipcode;
+
+    private Address(String city, String street, String zipcode) {
+        validate(city, street, zipcode);
+        this.city = city;
+        this.street = street;
+        this.zipcode = zipcode;
+    }
+
+    public static Address of(final String city, final String street, final String zipcode) {
+        return Address.builder().city(city).street(street).zipcode(zipcode).build();
+    }
+
+    private void validate(String city, String street, String zipcode) {
+        if (city == null || city.isBlank()) {
+            throw new IllegalArgumentException("city must not be null or blank");
+        }
+        if (street == null || street.isBlank()) {
+            throw new IllegalArgumentException("street must not be null or blank");
+        }
+        if (zipcode == null || zipcode.isBlank()) {
+            throw new IllegalArgumentException("zipcode must not be null or blank");
+        }
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/core/user/vo/City.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/vo/City.java
@@ -1,0 +1,39 @@
+package domainstructure.domainstructure.core.user.vo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import domainstructure.domainstructure.core.user.type.CityType;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class City {
+    private final CityType value;
+
+    private City(CityType value) {
+        validate(value);
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static City from(String name) {
+        return new City(CityType.from(name));
+    }
+
+    public static City of(CityType cityType) {
+        return new City(cityType);
+    }
+
+    private void validate(CityType value) {
+        if (value == null) {
+            throw new IllegalArgumentException("city must not be null");
+        }
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/core/user/vo/HashedPassword.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/vo/HashedPassword.java
@@ -1,0 +1,35 @@
+package domainstructure.domainstructure.core.user.vo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Getter
+@EqualsAndHashCode
+public class HashedPassword {
+    private static final String INVALID_PASSWORD_MESSAGE = "invalid password";
+    private final String value;
+
+    private HashedPassword(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static HashedPassword of(String value) {
+        return new HashedPassword(value);
+    }
+
+    private void validate(String value) {
+        Optional.ofNullable(value).orElseThrow(() -> new IllegalArgumentException(INVALID_PASSWORD_MESSAGE));
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/core/user/vo/HashedPassword.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/vo/HashedPassword.java
@@ -19,7 +19,7 @@ public class HashedPassword {
     }
 
     @JsonCreator
-    public static HashedPassword of(String value) {
+    public static HashedPassword of(final String value) {
         return new HashedPassword(value);
     }
 

--- a/src/main/java/domainstructure/domainstructure/core/user/vo/Nickname.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/vo/Nickname.java
@@ -1,0 +1,39 @@
+package domainstructure.domainstructure.core.user.vo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Getter
+@EqualsAndHashCode
+public class Nickname {
+    private static final int MAX_NICKNAME_LENGTH = 10;
+    private final String value;
+
+    private Nickname(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static Nickname of(String value) {
+        return new Nickname(value);
+    }
+
+    private void validate(String value) {
+        Optional.ofNullable(value)
+                .filter(v -> !v.isBlank())
+                .filter(v -> v.length() <= MAX_NICKNAME_LENGTH)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid nickname"));
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return value;
+    }
+
+}

--- a/src/main/java/domainstructure/domainstructure/core/user/vo/UserID.java
+++ b/src/main/java/domainstructure/domainstructure/core/user/vo/UserID.java
@@ -1,0 +1,34 @@
+package domainstructure.domainstructure.core.user.vo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class UserID {
+    private final String value;
+
+    private UserID(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static UserID of(String value) {
+        return new UserID(value);
+    }
+
+    private void validate(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Invalid user ID");
+        }
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/common/converter/EmailConverter.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/common/converter/EmailConverter.java
@@ -1,0 +1,17 @@
+package domainstructure.domainstructure.infrastructure.common.converter;
+
+import domainstructure.domainstructure.core.common.Email;
+import jakarta.persistence.AttributeConverter;
+
+public class EmailConverter implements AttributeConverter<Email, String> {
+    @Override
+    public String convertToDatabaseColumn(Email attribute) {
+        return attribute == null ? null : attribute.getValue();
+    }
+
+    @Override
+    public Email convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : Email.of(dbData);
+    }
+
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/common/converter/EmailConverter.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/common/converter/EmailConverter.java
@@ -1,6 +1,6 @@
 package domainstructure.domainstructure.infrastructure.common.converter;
 
-import domainstructure.domainstructure.core.common.Email;
+import domainstructure.domainstructure.core.common.vo.Email;
 import jakarta.persistence.AttributeConverter;
 
 public class EmailConverter implements AttributeConverter<Email, String> {

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/converter/CityConverter.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/converter/CityConverter.java
@@ -3,6 +3,7 @@ package domainstructure.domainstructure.infrastructure.user.converter;
 import domainstructure.domainstructure.core.user.vo.City;
 import jakarta.persistence.AttributeConverter;
 
+
 public class CityConverter implements AttributeConverter<City, String> {
     @Override
     public String convertToDatabaseColumn(City attribute) {

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/converter/CityConverter.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/converter/CityConverter.java
@@ -1,0 +1,16 @@
+package domainstructure.domainstructure.infrastructure.user.converter;
+
+import domainstructure.domainstructure.core.user.vo.City;
+import jakarta.persistence.AttributeConverter;
+
+public class CityConverter implements AttributeConverter<City, String> {
+    @Override
+    public String convertToDatabaseColumn(City attribute) {
+        return attribute != null ? attribute.toString() : null;
+    }
+
+    @Override
+    public City convertToEntityAttribute(String dbData) {
+        return dbData != null ? City.from(dbData) : null;
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/converter/HashedPasswordConverter.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/converter/HashedPasswordConverter.java
@@ -1,0 +1,17 @@
+package domainstructure.domainstructure.infrastructure.user.converter;
+
+import domainstructure.domainstructure.core.user.vo.HashedPassword;
+import jakarta.persistence.AttributeConverter;
+
+public class HashedPasswordConverter implements AttributeConverter<HashedPassword, String> {
+    @Override
+    public String convertToDatabaseColumn(HashedPassword attribute) {
+        return attribute == null ? null : attribute.getValue();
+    }
+
+    @Override
+    public HashedPassword convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : HashedPassword.of(dbData);
+    }
+
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/converter/NicknameConverter.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/converter/NicknameConverter.java
@@ -1,0 +1,17 @@
+package domainstructure.domainstructure.infrastructure.user.converter;
+
+import domainstructure.domainstructure.core.user.vo.Nickname;
+import jakarta.persistence.AttributeConverter;
+
+public class NicknameConverter implements AttributeConverter<Nickname, String> {
+    @Override
+    public String convertToDatabaseColumn(Nickname attribute) {
+        return attribute != null ? attribute.toString() : null;
+    }
+
+    @Override
+    public Nickname convertToEntityAttribute(String dbData) {
+        return dbData != null ? Nickname.of(dbData) : null;
+    }
+
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/converter/UserIDConverter.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/converter/UserIDConverter.java
@@ -9,7 +9,9 @@ import java.util.UUID;
 public class UserIDConverter implements AttributeConverter<UserID, byte[]> {
     @Override
     public byte[] convertToDatabaseColumn(UserID attribute) {
-        if (attribute == null) return null;
+        if (attribute == null) {
+            return null;
+        }
         UUID uuid = UUID.fromString(attribute.getValue());
         ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
         bb.putLong(uuid.getMostSignificantBits());
@@ -19,7 +21,9 @@ public class UserIDConverter implements AttributeConverter<UserID, byte[]> {
 
     @Override
     public UserID convertToEntityAttribute(byte[] dbData) {
-        if (dbData == null || dbData.length != 16) return null;
+        if (dbData == null || dbData.length != 16) {
+            return null;
+        }
         ByteBuffer bb = ByteBuffer.wrap(dbData);
         long high = bb.getLong();
         long low = bb.getLong();

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/converter/UserIDConverter.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/converter/UserIDConverter.java
@@ -1,0 +1,29 @@
+package domainstructure.domainstructure.infrastructure.user.converter;
+
+import domainstructure.domainstructure.core.user.vo.UserID;
+import jakarta.persistence.AttributeConverter;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+public class UserIDConverter implements AttributeConverter<UserID, byte[]> {
+    @Override
+    public byte[] convertToDatabaseColumn(UserID attribute) {
+        if (attribute == null) return null;
+        UUID uuid = UUID.fromString(attribute.getValue());
+        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+        return bb.array();
+    }
+
+    @Override
+    public UserID convertToEntityAttribute(byte[] dbData) {
+        if (dbData == null || dbData.length != 16) return null;
+        ByteBuffer bb = ByteBuffer.wrap(dbData);
+        long high = bb.getLong();
+        long low = bb.getLong();
+        UUID uuid = new UUID(high, low);
+        return UserID.of(uuid.toString());
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/embeddable/AccountEmbeddable.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/embeddable/AccountEmbeddable.java
@@ -1,0 +1,36 @@
+package domainstructure.domainstructure.infrastructure.user.embeddable;
+
+import domainstructure.domainstructure.core.common.Email;
+import domainstructure.domainstructure.core.user.vo.Account;
+import domainstructure.domainstructure.core.user.vo.HashedPassword;
+import domainstructure.domainstructure.infrastructure.common.converter.EmailConverter;
+import domainstructure.domainstructure.infrastructure.user.converter.HashedPasswordConverter;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+public class AccountEmbeddable {
+    @Convert(converter = EmailConverter.class)
+    private Email username;
+
+    @Convert(converter = HashedPasswordConverter.class)
+    private HashedPassword password;
+
+    private AccountEmbeddable(Email username, HashedPassword password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public static AccountEmbeddable of(final Account account) {
+        return new AccountEmbeddable(account.getUsername(), account.getPassword());
+    }
+
+    public Account toDomain() {
+        return Account.of(username, password);
+    }
+
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/embeddable/AccountEmbeddable.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/embeddable/AccountEmbeddable.java
@@ -28,9 +28,4 @@ public class AccountEmbeddable {
     public static AccountEmbeddable of(final Account account) {
         return new AccountEmbeddable(account.getUsername(), account.getPassword());
     }
-
-    public Account toDomain() {
-        return Account.of(username, password);
-    }
-
 }

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/embeddable/AccountEmbeddable.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/embeddable/AccountEmbeddable.java
@@ -1,6 +1,6 @@
 package domainstructure.domainstructure.infrastructure.user.embeddable;
 
-import domainstructure.domainstructure.core.common.Email;
+import domainstructure.domainstructure.core.common.vo.Email;
 import domainstructure.domainstructure.core.user.vo.Account;
 import domainstructure.domainstructure.core.user.vo.HashedPassword;
 import domainstructure.domainstructure.infrastructure.common.converter.EmailConverter;

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/entity/AddressEntity.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/entity/AddressEntity.java
@@ -27,14 +27,23 @@ public class AddressEntity {
     @Column(name = "zipcode")
     private String zipcode;
 
-    private AddressEntity(Long id, City city, String street, String zipcode) {
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    private AddressEntity(Long id, City city, String street, String zipcode, UserEntity user) {
         this.id = id;
         this.city = city;
         this.street = street;
         this.zipcode = zipcode;
+        this.user = user;
     }
 
     public static AddressEntity of(Long id, City city, String street, String zipcode) {
-        return new AddressEntity(id, city, street, zipcode);
+        return new AddressEntity(id, city, street, zipcode, null);
+    }
+
+    public void associateUser(UserEntity user) {
+        this.user = user;
     }
 }

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/entity/AddressEntity.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/entity/AddressEntity.java
@@ -1,0 +1,40 @@
+package domainstructure.domainstructure.infrastructure.user.entity;
+
+
+import domainstructure.domainstructure.core.user.vo.City;
+import domainstructure.domainstructure.infrastructure.user.converter.CityConverter;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "address")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AddressEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "city")
+    @Convert(converter = CityConverter.class)
+    private City city;
+
+    @Column(name = "street")
+    private String street;
+
+    @Column(name = "zipcode")
+    private String zipcode;
+
+    private AddressEntity(Long id, City city, String street, String zipcode) {
+        this.id = id;
+        this.city = city;
+        this.street = street;
+        this.zipcode = zipcode;
+    }
+
+    public static AddressEntity of(Long id, City city, String street, String zipcode) {
+        return new AddressEntity(id, city, street, zipcode);
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/entity/ProfileEntity.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/entity/ProfileEntity.java
@@ -25,13 +25,22 @@ public class ProfileEntity {
     @Column(name = "birthday")
     private LocalDate birthday;
 
-    private ProfileEntity(Long id, Nickname nickname, LocalDate birthday) {
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    private ProfileEntity(Long id, Nickname nickname, LocalDate birthday, UserEntity user) {
         this.id = id;
         this.nickname = nickname;
         this.birthday = birthday;
+        this.user = user;
     }
 
     public static ProfileEntity of(Long id, Nickname nickname, LocalDate birthday) {
-        return new ProfileEntity(id, nickname, birthday);
+        return new ProfileEntity(id, nickname, birthday, null);
+    }
+
+    public void associateUser(UserEntity user) {
+        this.user = user;
     }
 }

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/entity/ProfileEntity.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/entity/ProfileEntity.java
@@ -1,0 +1,37 @@
+package domainstructure.domainstructure.infrastructure.user.entity;
+
+import domainstructure.domainstructure.core.user.vo.Nickname;
+import domainstructure.domainstructure.infrastructure.user.converter.NicknameConverter;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "profile")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProfileEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    @Convert(converter = NicknameConverter.class)
+    private Nickname nickname;
+
+    @Column(name = "birthday")
+    private LocalDate birthday;
+
+    private ProfileEntity(Long id, Nickname nickname, LocalDate birthday) {
+        this.id = id;
+        this.nickname = nickname;
+        this.birthday = birthday;
+    }
+
+    public static ProfileEntity of(Long id, Nickname nickname, LocalDate birthday) {
+        return new ProfileEntity(id, nickname, birthday);
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/entity/UserEntity.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/entity/UserEntity.java
@@ -1,0 +1,49 @@
+package domainstructure.domainstructure.infrastructure.user.entity;
+
+import domainstructure.domainstructure.core.user.vo.UserID;
+import domainstructure.domainstructure.infrastructure.user.converter.UserIDConverter;
+import domainstructure.domainstructure.infrastructure.user.embeddable.AccountEmbeddable;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user")
+@Getter
+@NoArgsConstructor
+public class UserEntity {
+    @Id
+    @Convert(converter = UserIDConverter.class)
+    @Column(columnDefinition = "binary(16)")
+    private UserID id;
+
+    @Embedded
+    private AccountEmbeddable account;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private ProfileEntity profile;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private AddressEntity address;
+
+    private UserEntity(UserID id, AccountEmbeddable account, ProfileEntity profile, AddressEntity address) {
+        this.id = id;
+        this.account = account;
+        this.profile = profile;
+        this.address = address;
+    }
+
+    public static UserEntity of(UserID id, AccountEmbeddable account, ProfileEntity profile, AddressEntity address) {
+        UserEntity entity = new UserEntity(id, account, profile, address);
+
+        if (profile != null) {
+            profile.associateUser(entity);
+        }
+        if (address != null) {
+            address.associateUser(entity);
+        }
+        return entity;
+    }
+
+
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/AccountMapper.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/AccountMapper.java
@@ -2,7 +2,9 @@ package domainstructure.domainstructure.infrastructure.user.mapper;
 
 import domainstructure.domainstructure.core.user.vo.Account;
 import domainstructure.domainstructure.infrastructure.user.embeddable.AccountEmbeddable;
+import lombok.experimental.UtilityClass;
 
+@UtilityClass
 public class AccountMapper {
     public static AccountEmbeddable toEmbeddable(Account account) {
         return AccountEmbeddable.of(account);

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/AccountMapper.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/AccountMapper.java
@@ -1,0 +1,17 @@
+package domainstructure.domainstructure.infrastructure.user.mapper;
+
+import domainstructure.domainstructure.core.user.vo.Account;
+import domainstructure.domainstructure.infrastructure.user.embeddable.AccountEmbeddable;
+
+public class AccountMapper {
+    public static AccountEmbeddable toEmbeddable(Account account) {
+        return AccountEmbeddable.of(account);
+    }
+
+    public static Account toDomain(AccountEmbeddable embeddable) {
+        if (embeddable == null) {
+            return null;
+        }
+        return Account.of(embeddable.getUsername(), embeddable.getPassword());
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/AddressMapper.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/AddressMapper.java
@@ -1,0 +1,32 @@
+package domainstructure.domainstructure.infrastructure.user.mapper;
+
+import domainstructure.domainstructure.core.user.model.Address;
+import domainstructure.domainstructure.infrastructure.user.entity.AddressEntity;
+
+
+public class AddressMapper {
+
+    public static AddressEntity toEntity(Address address) {
+        if (address == null) {
+            return null;
+        }
+        return AddressEntity.of(
+                address.getId(),
+                address.getCity(),
+                address.getStreet(),
+                address.getZipcode()
+        );
+    }
+
+    public static Address toDomain(AddressEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return Address.of(
+                entity.getId(),
+                entity.getCity(),
+                entity.getStreet(),
+                entity.getZipcode()
+        );
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/AddressMapper.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/AddressMapper.java
@@ -2,8 +2,9 @@ package domainstructure.domainstructure.infrastructure.user.mapper;
 
 import domainstructure.domainstructure.core.user.model.Address;
 import domainstructure.domainstructure.infrastructure.user.entity.AddressEntity;
+import lombok.experimental.UtilityClass;
 
-
+@UtilityClass
 public class AddressMapper {
 
     public static AddressEntity toEntity(Address address) {

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/ProfileMapper.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/ProfileMapper.java
@@ -2,8 +2,9 @@ package domainstructure.domainstructure.infrastructure.user.mapper;
 
 import domainstructure.domainstructure.core.user.model.Profile;
 import domainstructure.domainstructure.infrastructure.user.entity.ProfileEntity;
+import lombok.experimental.UtilityClass;
 
-
+@UtilityClass
 public class ProfileMapper {
     public static ProfileEntity toEntity(Profile profile) {
         if (profile == null) {

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/ProfileMapper.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/ProfileMapper.java
@@ -1,0 +1,29 @@
+package domainstructure.domainstructure.infrastructure.user.mapper;
+
+import domainstructure.domainstructure.core.user.model.Profile;
+import domainstructure.domainstructure.infrastructure.user.entity.ProfileEntity;
+
+
+public class ProfileMapper {
+    public static ProfileEntity toEntity(Profile profile) {
+        if (profile == null) {
+            return null;
+        }
+        return ProfileEntity.of(
+                profile.getId(),
+                profile.getNickname(),
+                profile.getBirthday()
+        );
+    }
+
+    public static Profile toDomain(ProfileEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return Profile.of(
+                entity.getId(),
+                entity.getNickname(),
+                entity.getBirthday()
+        );
+    }
+}

--- a/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/UserMapper.java
+++ b/src/main/java/domainstructure/domainstructure/infrastructure/user/mapper/UserMapper.java
@@ -1,0 +1,34 @@
+package domainstructure.domainstructure.infrastructure.user.mapper;
+
+import domainstructure.domainstructure.core.user.model.User;
+import domainstructure.domainstructure.infrastructure.user.embeddable.AccountEmbeddable;
+import domainstructure.domainstructure.infrastructure.user.entity.AddressEntity;
+import domainstructure.domainstructure.infrastructure.user.entity.ProfileEntity;
+import domainstructure.domainstructure.infrastructure.user.entity.UserEntity;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class UserMapper {
+    public static UserEntity toEntity(User user) {
+        if (user == null) {
+            return null;
+        }
+
+        AccountEmbeddable accountEmbeddable = AccountMapper.toEmbeddable(user.getAccount());
+        ProfileEntity profileEntity = ProfileMapper.toEntity(user.getProfile());
+        AddressEntity addressEntity = AddressMapper.toEntity(user.getAddress());
+
+        return UserEntity.of(user.getId(), accountEmbeddable, profileEntity, addressEntity);
+    }
+
+    public static User toDomain(UserEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return User.of(entity.getId(),
+                       AccountMapper.toDomain(entity.getAccount()),
+                       ProfileMapper.toDomain(entity.getProfile()),
+                       AddressMapper.toDomain(entity.getAddress()));
+    }
+}


### PR DESCRIPTION
# Summary
> 작업한 내용에 대하여 한 줄 정도의 간단한 설명을 작성해주세요.
User 도메인 구조를 DDD 및 JPA 기반으로 설계하고, 명시적 VO 관리를 위한 구조를 추가합니다.

# Description
> 작업한 내용에 대한 상세한 내용을 추가해주세요.
> 작업의 배경지식, 구현 상 설명이 필요한 내용, 꼭 확인해야하는 변경사항등을 서술해주세요.
> 다이어그램이나 표를 첨부해주시면 좋습니다.

User 도메인의 구조를 DDD 설계 원칙을 기반으로 구현했습니다.

### 주요 변경 및 추가 사항

- UserID를 명시적인 UUID 기반 VO로 관리하고, 데이터베이스에는 최적화를 위해 `BINARY(16)` 형태로 저장합니다.
    - 이를 위해 `UserIDConverter`를 구현하여 JPA와의 변환을 명확하게 처리했습니다.
    - UUID 생성 책임을 명확하게 하기 위해 `UserIDGenerator`를 별도로 분리했습니다.

- Address와 Profile은 별도의 테이블에 정규화하여 저장하며, 이로 인해 도메인 모델에도 식별자(ID)를 추가하여 JPA와의 일관성을 유지했습니다.
    - Address와 Profile은 User 하위의 종속 엔티티로, 각각 별도의 테이블에 1:1로 매핑됩니다.

- 도메인 객체와 인프라 Entity 간의 변환은 명확한 Mapper 클래스를 통해 관리합니다.
    - Account, Address, Profile, User 각각의 Mapper를 작성하여 책임을 명확히 분리했습니다.

- Email, Nickname, HashedPassword, City 등의 도메인 VO도 명시적으로 관리하며, 각 객체마다 유효성 검사를 추가하여 도메인 규칙을 검증합니다.

### 패키지 구조 요약
```
core/
├── common
│   └── vo (Email 등 공통 VO)
└── user
    ├── model (Aggregate Root 및 Entity)
    ├── vo (User 도메인 VO)
    ├── type (enum 타입)
    └── support (도메인 유틸성 객체)

infrastructure/
├── common
│   └── converter (공통 Converter)
└── user
    ├── entity (JPA 엔티티)
    ├── embeddable (JPA 내장 타입)
    ├── converter (VO ↔ DB 변환)
    └── mapper (Entity ↔ Domain 변환)
```

### 클래스 다이어그램
```mermaid
classDiagram
    class User {
        +UserID id
        +Account account
        +Profile profile
        +Address address
    }

    class Account {
        +Email username
        +HashedPassword password
    }

    class Profile {
        +Long id
        +Nickname nickname
        +LocalDate birthday
    }

    class Address {
        +Long id
        +City city
        +String street
        +String zipcode
    }

    class Email
    class HashedPassword
    class Nickname
    class City
    class UserID

    User --> Account
    User --> Profile
    User --> Address

    Account --> Email
    Account --> HashedPassword

    Profile --> Nickname
    Address --> City

    %% === Entity ===

    class UserEntity {
        +UserID id
        +AccountEmbeddable account
        +ProfileEntity profile
        +AddressEntity address
    }

    class ProfileEntity {
        +Long id
        +Nickname nickname
        +LocalDate birthday
    }

    class AddressEntity {
        +Long id
        +City city
        +String street
        +String zipcode
    }

    class AccountEmbeddable {
        +Email username
        +HashedPassword password
    }

    UserEntity --> AccountEmbeddable
    UserEntity --> ProfileEntity
    UserEntity --> AddressEntity

    ProfileEntity --> UserEntity
    AddressEntity --> UserEntity

```

## ER 다이어그램
```mermaid
erDiagram
    user {
        BINARY(16) id PK
        VARCHAR username
        VARCHAR password
    }

    profile {
        BIGINT id PK
        VARCHAR nickname
        DATE birthday
        BINARY(16) user_id FK
    }

    address {
        BIGINT id PK
        VARCHAR city
        VARCHAR street
        VARCHAR zipcode
        BINARY(16) user_id FK
    }

    user ||--o| profile : has
    user ||--o| address : has

```

### 확인해야 하는 부분
- UserID → BINARY(16) 변환 로직(`UserIDConverter.java`)
- Address 및 Profile Entity의 JPA 연관 관계 설정
- Mapper 클래스에서 Entity ↔ Domain 객체 변환 로직이 정확한지 여부
- 각 VO의 유효성 검사 로직이 적절한지 여부

### TODO
- Address 내의 street, zipcode도 VO로 추가 분리 예정입니다.

# Reference
- [노션]()
- [슬랙]()